### PR TITLE
Fix SHA-256 hex padding

### DIFF
--- a/StudentDB/src/model/CyberStudent.java
+++ b/StudentDB/src/model/CyberStudent.java
@@ -28,7 +28,7 @@ public class CyberStudent extends Student {
 			StringBuilder hexString = new StringBuilder();
 			for (byte b : hashBytes) {
 				String hex = Integer.toHexString(0xff & b);
-				if (hex.length() == 1) hexString.append(0);
+                                if (hex.length() == 1) hexString.append('0');
 				hexString.append(hex);
 			}
 			


### PR DESCRIPTION
## Summary
- use `'0'` to pad single hex digits in `CyberStudent.showSkill`

## Testing
- `javac -d StudentDB/bin $(find StudentDB/src -name '*.java')`
- `java -cp /tmp:StudentDB/bin TestCyber`

------
https://chatgpt.com/codex/tasks/task_e_6842ca2f0ff88332a13759f750737c1f